### PR TITLE
hash changes on nairr-report tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,9 @@ bower_components
 .bower-tmp
 
 .php-cs-fixer.cache
+.php-cs-fixer.php
 
+httpd/
 
 
 

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -305,6 +305,7 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           setHashParams({});
         },
         activate: () => {
+          this.isRestoringState = true;
           let hashParams = getHashParams();
           this.viewingState = {
             year:
@@ -324,6 +325,7 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           ) {
             setHashParams(this.viewingState);
           }
+          this.isRestoringState = false;
         },
       },
     });

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -111,7 +111,25 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
 
     const initialUrl = buildReportUrl(defaultYear, defaultMonth);
 
-    // Use hash for constructing report links
+    if (!window._nairrReportsHashHandler) {
+      window._nairrReportsHashHandler = true;
+      window.addEventListener("hashchange", function () {
+        let tabPanel = Ext.getCmp("main_tab_panel");
+        let activeTab = tabPanel ? tabPanel.getActiveTab() : null;
+        if (activeTab) {
+          let params = getHashParams();
+          XDMoD.Module.NairrReports.prototype.reloadReports(
+            params.year,
+            params.month,
+          );
+          if (params.report_id) {
+            triggerReportDownload(params.report_id, params.year, params.month);
+          }
+        }
+      });
+    }
+
+    // Use hash for constructing report links;
     const getCustomReportQueryString = () => {
       let hashParams = getHashParams();
       const year = hashParams.year || defaultYear;
@@ -261,7 +279,6 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
       listeners: {
         click: (node) => {
           if (!node.isLeaf()) return;
-          if (this.isRestoringState) return;
           let hashParams = getHashParams();
           const year = node.parentNode.text;
           const month = node.text;
@@ -296,17 +313,18 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
       listeners: {
         deactivate: () => {
           let hashParams = getHashParams();
-          if (hashParams.year && hashParams.month) {
+          if (hashParams.year && hashParams.month) this.viewingState = null;
+          {
             this.lastViewState = {
               year: hashParams.year,
               month: hashParams.month,
             };
           }
-          setHashParams({});
+          setHashParams(hashParams);
         },
         activate: () => {
-          this.isRestoringState = true;
           let hashParams = getHashParams();
+          console.log("Activating NAIRR Reports with hash params:", hashParams);
           this.viewingState = {
             year:
               hashParams.year ||
@@ -318,14 +336,16 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
               defaultMonth,
             report_id: hashParams.report_id || null,
           };
+
+          console.log("Restored viewing state:", this.viewingState);
           // Only set hash if missing or out of sync
           if (
             hashParams.year !== this.viewingState.year ||
             hashParams.month !== this.viewingState.month
           ) {
+            console.log("Setting hash params to:", this.viewingState);
             setHashParams(this.viewingState);
           }
-          this.isRestoringState = false;
         },
       },
     });

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -238,7 +238,6 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
       reportStore.on("load", function (store, records, success) {
         reportContainer.updateReports(records);
         let hashParams = getHashParams();
-        expandAndSelect(leftPanel, hashParams.year, hashParams.month, false);
         if (!success) {
           console.error("Failed to load reports.");
           reportContainer.body.update(`
@@ -323,7 +322,6 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           setHashParams(hashParams);
         },
         activate: () => {
-          if (reportContainer) reportContainer.body.mask("Loading...");
           let hashParams = getHashParams();
           this.viewingState = {
             year:
@@ -344,6 +342,7 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           ) {
             setHashParams(this.viewingState);
           }
+          expandAndSelect(leftPanel, hashParams.year, hashParams.month, false);
         },
       },
     });

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -282,7 +282,7 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           let hashParams = getHashParams();
           const year = node.parentNode.text;
           const month = node.text;
-
+          if (reportContainer) reportContainer.body.mask("Loading...");
           delete hashParams.report_id;
           hashParams.year = year;
           hashParams.month = month;

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -2,9 +2,28 @@
  * NAIRR Reports Module for XDMoD Portal
  * @author Alex Tovar
  * @date 2025-07-14
+ * @updated 2025-09-29
  *
- * This module displays NAIRR reports fetched from the `/custom_reports/reports` endpoint.
- * It integrates with XDMoD's main tab panel and allows browsing reports by year/month.
+ * This module provides a user interface for browsing and downloading NAIRR custom reports
+ * within the XDMoD Portal. Reports are dynamically fetched from the `/custom_reports/reports`
+ * REST endpoint, and are organized by year and month for ease of navigation.
+ *
+ * Key Features:
+ * - Tree-based directory navigation of reports by year and month.
+ * - Dynamic fetching and display of available reports, including thumbnails and metadata.
+ * - Direct report downloads, triggered via a hidden iframe for seamless user experience.
+ * - URL hash management: The current state (year, month, and optional report ID) is always
+ *   encoded in the URL hash, enabling:
+ *     - Deep linking/bookmarking to specific views or downloads.
+ *     - State restoration on reload or after SSO redirection.
+ *     - Back/forward navigation support.
+ * - User-friendly handling of empty or error states.
+ * - Designed for integration with the Ext JS framework and XDMoD’s existing module system.
+ *
+ * Usage:
+ * - Place this module in the XDMoD Portal.
+ * - Navigating the tree or triggering downloads will update the URL hash accordingly.
+ * - Direct links to a specific report or month/year view are supported and restored on load.
  */
 
 function buildReportUrl(year, month) {
@@ -18,7 +37,37 @@ function triggerReportDownload(reportId, year, month) {
   if (year) qs.push(`year=${encodeURIComponent(year)}`);
   if (month) qs.push(`month=${encodeURIComponent(month)}`);
   const url = `${XDMoD.REST.prependPathBase("/custom_reports/report/")}${reportId}${qs.length ? "?" + qs.join("&") : ""}`;
-  window.location.href = url;
+  let iframe = document.getElementById("nairr_report_download_iframe");
+  if (!iframe) {
+    iframe = document.createElement("iframe");
+    iframe.style.display = "none";
+    iframe.id = "nairr_report_download_iframe";
+    document.body.appendChild(iframe);
+  }
+  iframe.src = url;
+}
+
+// Utility to get params from hash instead of query string
+function getHashParams() {
+  const hash = window.location.hash.split("?")[1] || "";
+  const params = new URLSearchParams(hash);
+  return {
+    year: params.get("year"),
+    month: params.get("month"),
+    report_id: params.get("report_id"),
+  };
+}
+
+// Utility to set params in hash, preserving tab info
+function setHashParams(obj) {
+  // Preserve tab info (e.g. #main_tab_panel:nairr_reports)
+  const pre =
+    window.location.hash.split("?")[0] || "#main_tab_panel:nairr_reports";
+  const params = new URLSearchParams();
+  if (obj.year) params.set("year", obj.year);
+  if (obj.month) params.set("month", obj.month);
+  if (obj.report_id) params.set("report_id", obj.report_id);
+  window.location.hash = `${pre}?${params.toString()}`;
 }
 
 XDMoD.Module.NairrReports = function (config) {
@@ -26,6 +75,7 @@ XDMoD.Module.NairrReports = function (config) {
 };
 
 Ext.apply(XDMoD.Module.NairrReports, {
+  // Accept config and update hash accordingly
   setConfig: function (config, name) {
     Ext.getCmp("main_tab_panel").setActiveTab("nairr_reports");
   },
@@ -35,45 +85,54 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
   module_id: "nairr_reports",
   usesToolbar: false,
   lastViewState: null,
+  isRestoringState: false,
+  viewingState: null,
 
   reloadReports: function (year, month) {
     var store = Ext.StoreMgr.get("customReportStore");
     if (!store) return;
-
     var mainPanel = Ext.getCmp("nairr_reports_main_panel");
     if (mainPanel) {
       mainPanel.setTitle(`NAIRR Reports for ${month} ${year}`);
     }
-
     store.proxy.conn.url = buildReportUrl(year, month);
     store.load();
   },
 
   initComponent: function () {
     // -----------------------------
-    // Default Params
+    // Default Params: now from hashE~Z!
     const now = new Date();
-    const urlParams = new URLSearchParams(window.location.search);
-    const defaultYear = urlParams.get("year") || now.getFullYear();
+    let hashParams = getHashParams();
+    const defaultYear = hashParams.year || now.getFullYear();
     const defaultMonth =
-      urlParams.get("month") ||
-      now.toLocaleString("default", { month: "long" });
+      hashParams.month || now.toLocaleString("default", { month: "long" });
+    let pendingReportId = hashParams.report_id || null;
+
     const initialUrl = buildReportUrl(defaultYear, defaultMonth);
 
+    // Use hash for constructing report links
     const getCustomReportQueryString = () => {
-      const params = new URLSearchParams(window.location.search);
-      const year = params.get("year") || defaultYear;
-      const month = params.get("month") || defaultMonth;
+      let hashParams = getHashParams();
+      const year = hashParams.year || defaultYear;
+      const month = hashParams.month || defaultMonth;
       const out = [];
       if (year) out.push(`year=${encodeURIComponent(year)}`);
       if (month) out.push(`month=${encodeURIComponent(month)}`);
       return out.length ? "?" + out.join("&") : "";
     };
+    const expandAndSelect = (tree, year, month, clickNode) => {
+      const yearNode = tree.getRootNode().findChild("text", String(year));
+      if (!yearNode) return;
+      yearNode.expand(false, false, function () {
+        const monthNode = yearNode.findChild("text", String(month));
+        if (!monthNode) return;
+        tree.getSelectionModel().select(monthNode);
+        monthNode.ensureVisible();
+        if (clickNode) monthNode.fireEvent("click", monthNode);
+      });
+    };
 
-    // -----------------------------
-    //
-    //
-    //
     const reportStore = new Ext.data.JsonStore({
       autoDestroy: true,
       autoLoad: true,
@@ -158,29 +217,35 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
     });
 
     reportContainer.on("afterrender", function () {
-      reportStore.on("load", function (store, records) {
+      reportStore.on("load", function (store, records, success) {
         reportContainer.updateReports(records);
-        const params = new URLSearchParams(window.location.search);
-        const reportId = params.get("report_id");
-        if (reportId && records.some((r) => r.data.name === reportId)) {
-          triggerReportDownload(reportId, defaultYear, defaultMonth);
-          const newUrl = new URL(window.location.href);
-          newUrl.searchParams.delete("report_id");
-          window.history.replaceState({}, "", newUrl.toString());
+        let hashParams = getHashParams();
+        expandAndSelect(leftPanel, hashParams.year, hashParams.month, false);
+        if (!success) {
+          console.error("Failed to load reports.");
+          reportContainer.body.update(`
+              <div class="no-reports-container">
+                <div class="no-reports-icon">&#9888;</div>
+                <div class="no-reports-title">Failed to load reports. Please try again.</div>
+              </div>
+            `);
+          return;
+        }
+
+        if (pendingReportId) {
+          const matching = records.find((r) => r.data.name === pendingReportId);
+          if (matching) {
+            triggerReportDownload(
+              pendingReportId,
+              hashParams.year || defaultYear,
+              hashParams.month || defaultMonth,
+            );
+
+            pendingReportId = null;
+          }
         }
       });
     });
-    const expandAndSelect = (tree, year, month, clickNode) => {
-      const yearNode = tree.getRootNode().findChild("text", String(year));
-      if (!yearNode) return;
-      yearNode.expand(false, false, function () {
-        const monthNode = yearNode.findChild("text", String(month));
-        if (!monthNode) return;
-        tree.getSelectionModel().select(monthNode);
-        monthNode.ensureVisible();
-        if (clickNode) monthNode.fireEvent("click", monthNode);
-      });
-    };
 
     const leftPanel = new Ext.tree.TreePanel({
       region: "west",
@@ -196,24 +261,25 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
       listeners: {
         click: (node) => {
           if (!node.isLeaf()) return;
+          if (this.isRestoringState) return;
+          let hashParams = getHashParams();
           const year = node.parentNode.text;
           const month = node.text;
-          if (reportContainer) reportContainer.body.mask("Loading...");
 
-          const newUrl = new URL(window.location.href);
-          newUrl.searchParams.set("year", year);
-          newUrl.searchParams.set("month", month);
-          window.history.replaceState({}, "", newUrl.toString());
+          delete hashParams.report_id;
+          hashParams.year = year;
+          hashParams.month = month;
+          setHashParams(hashParams);
           this.reloadReports(year, month);
         },
         render: (tree) => {
           tree.getLoader().on("load", function (loader, node) {
             if (node.isRoot) {
-              const params = new URLSearchParams(window.location.search);
+              let hashParams = getHashParams();
               expandAndSelect(
                 tree,
-                params.get("year") || defaultYear,
-                params.get("month") || defaultMonth,
+                hashParams.year || defaultYear,
+                hashParams.month || defaultMonth,
                 true,
               );
             }
@@ -229,27 +295,35 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
       items: [leftPanel, mainArea],
       listeners: {
         deactivate: () => {
-          const params = new URLSearchParams(window.location.search);
-          const year = params.get("year");
-          const month = params.get("month");
-          if (year && month) this.lastViewState = { year, month };
-          const url = new URL(window.location.href);
-          url.searchParams.delete("year");
-          url.searchParams.delete("month");
-          window.history.replaceState({}, "", url.toString());
+          let hashParams = getHashParams();
+          if (hashParams.year && hashParams.month) {
+            this.lastViewState = {
+              year: hashParams.year,
+              month: hashParams.month,
+            };
+          }
+          setHashParams({});
         },
         activate: () => {
-          let year = defaultYear;
-          let month = defaultMonth;
-          if (this.lastViewState) {
-            year = this.lastViewState.year;
-            month = this.lastViewState.month;
+          let hashParams = getHashParams();
+          this.viewingState = {
+            year:
+              hashParams.year ||
+              (this.lastViewState && this.lastViewState.year) ||
+              defaultYear,
+            month:
+              hashParams.month ||
+              (this.lastViewState && this.lastViewState.month) ||
+              defaultMonth,
+            report_id: hashParams.report_id || null,
+          };
+          // Only set hash if missing or out of sync
+          if (
+            hashParams.year !== this.viewingState.year ||
+            hashParams.month !== this.viewingState.month
+          ) {
+            setHashParams(this.viewingState);
           }
-          const url = new URL(window.location.href);
-          url.searchParams.set("year", year);
-          url.searchParams.set("month", month);
-          window.history.replaceState({}, "", url.toString());
-          expandAndSelect(leftPanel, year, month, false);
         },
       },
     });

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -322,6 +322,9 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           setHashParams(hashParams);
         },
         activate: () => {
+          if (reportContainer)
+            reportContainer.body.update("") &&
+              reportContainer.body.mask("Loading...");
           let hashParams = getHashParams();
           this.viewingState = {
             year:

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -323,6 +323,7 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           setHashParams(hashParams);
         },
         activate: () => {
+          if (reportContainer) reportContainer.body.mask("Loading...");
           let hashParams = getHashParams();
           this.viewingState = {
             year:

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -281,7 +281,6 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
           let hashParams = getHashParams();
           const year = node.parentNode.text;
           const month = node.text;
-          if (reportContainer) reportContainer.body.mask("Loading...");
           delete hashParams.report_id;
           hashParams.year = year;
           hashParams.month = month;

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -324,7 +324,6 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
         },
         activate: () => {
           let hashParams = getHashParams();
-          console.log("Activating NAIRR Reports with hash params:", hashParams);
           this.viewingState = {
             year:
               hashParams.year ||
@@ -337,13 +336,11 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
             report_id: hashParams.report_id || null,
           };
 
-          console.log("Restored viewing state:", this.viewingState);
           // Only set hash if missing or out of sync
           if (
             hashParams.year !== this.viewingState.year ||
             hashParams.month !== this.viewingState.month
           ) {
-            console.log("Setting hash params to:", this.viewingState);
             setHashParams(this.viewingState);
           }
         },


### PR DESCRIPTION
The code now manages report navigation state (year, month, and report ID) using the URL hash instead of query parameters.
New utilities were added:
getHashParams() to parse hash parameters for year, month, and report ID.
setHashParams() to update the hash with the current navigation state.
The module ensures the hash is updated whenever the user navigates by year/month or triggers a download, enabling deep linking, bookmarking, and state restoration.
On reload or after SSO, the module restores the previous state from the hash, including selected year/month and pending report downloads.
Changes throughout the file replace usage of window.location.search and query string manipulation with hash-based equivalents.
Download logic now uses a hidden iframe instead of direct navigation, improving user experience.
Improved empty/error state handling and updated documentation/comments for clarity.

the iframe download has been tested on safari, chrome, firefox, and duckduckgo on mac 