### PR TITLE
updates to use the correct timing for when reports are generated

### DIFF
--- a/configuration/assets.d/nairr.json
+++ b/configuration/assets.d/nairr.json
@@ -1,7 +1,7 @@
 {
   "nairr": {
     "portal": {
-      "js": ["gui/js/modules/NairrReports.js"],
+      "js": ["gui/js/modules/NairrReports.js?v=1"],
       "css": ["gui/css/CustomReports.css"]
     }
   }

--- a/html/gui/js/modules/NairrReports.js
+++ b/html/gui/js/modules/NairrReports.js
@@ -79,9 +79,11 @@ Ext.extend(XDMoD.Module.NairrReports, XDMoD.PortalModule, {
 
     const now = new Date();
     let hashParams = getHashParams();
-    const defaultYear = hashParams.year || now.getFullYear();
+    const prevMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const defaultYear = hashParams.year || prevMonth.getFullYear();
     const defaultMonth =
-      hashParams.month || now.toLocaleString("default", { month: "long" });
+      hashParams.month ||
+      prevMonth.toLocaleString("default", { month: "long" });
     let pendingReportId = hashParams.report_id || null;
     const initialUrl = buildReportUrl(defaultYear, defaultMonth);
 


### PR DESCRIPTION
Had to update to use prev month for report viewing and make sure that the default year and month use the prevmonh and year associated with that month. 